### PR TITLE
Change initializer for factory support. Default is to initialize menu extension if not already done

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
 * Tibor Simko <tibor.simko@cern.ch>
 * Pierre Lucas <pierre.lucas@altie.fr>
 * Joshua Arnott <josh@snorfalorpagus.net>
+* Florian Merges <fmerges@fstarter.org>

--- a/flask_breadcrumbs/__init__.py
+++ b/flask_breadcrumbs/__init__.py
@@ -43,8 +43,14 @@ class Breadcrumbs(Menu, object):
 
     """Breadcrumb organizer for a :class:`~flask.Flask` application."""
 
-    def __init__(self, app, init_menu=False):
-        """Initialize Breadcrumb extension."""
+    def __init__(self, app=None, init_menu=True):
+        """Initialize Breadcrumb extension.
+
+        :param app: The :class:`flask.Flask` object to configure.
+        :type app: :class:`flask.Flask`
+        :param init_menu: If Flask-Menu should be initialized.
+        :type init_menu: bool
+        """
         self.init_menu = init_menu
         if app is not None:
             self.init_app(app)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -185,11 +185,11 @@ class TestBreadcrumbs(FlaskTestCase):
 class MenuIntegrationTestCase(FlaskTestCase):
 
     def test_without_menu(self):
-        # it must raise an exception because is not registered.
-        self.assertRaises(RuntimeError, Breadcrumbs, self.app)
+        # it must raise an exception because it is not registered.
+        self.assertRaises(RuntimeError, Breadcrumbs, self.app, False)
 
     def test_init_menu(self):
-        Breadcrumbs(self.app, init_menu=True)
+        Breadcrumbs(self.app)
         assert 'menu' in self.app.extensions
 
     def test_create_menu_first(self):
@@ -197,5 +197,5 @@ class MenuIntegrationTestCase(FlaskTestCase):
         menu = Menu(self.app)
         entry = self.app.extensions['menu']
         # it must reuse existing menu extension.
-        Breadcrumbs(self.app)
+        Breadcrumbs(self.app, init_menu=False)
         assert entry == self.app.extensions['menu']


### PR DESCRIPTION
Hi,

In the current version, in order to make it work with the factory pattern, you have to provide a None to the Breadcrumb class.

I looked form the perspective of someone just using this extension so by default you do want to try to initialize the Flask-Menu extension if it's not already initialized.

Cheers,

Florian