### PR TITLE
global: fix Travis CI build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-Breadcrumbs
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2016 CERN.
 #
 # Flask-Breadcrumbs is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -16,15 +16,13 @@ python:
   - "3.4"
 
 install:
-  - pip install --upgrade pip  --use-mirrors
-  - pip install coveralls pep257 --use-mirrors
-  - pip install pytest pytest-pep8 pytest-cov pytest-cache --use-mirrors
+  - pip install --upgrade pip
+  - pip install coveralls pep257
+  - pip install pytest pytest-pep8 pytest-cov pytest-cache
   - pip install -e .[docs]
 
 script:
-  - pep257 flask_breadcrumbs
-  - "sphinx-build -qnNW docs docs/_build/html"
-  - python setup.py test
+  - "./run-tests.sh"
 
 after_success:
   - coveralls

--- a/flask_breadcrumbs/__init__.py
+++ b/flask_breadcrumbs/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-Breadcrumbs
-# Copyright (C) 2013, 2014, 2015 CERN.
+# Copyright (C) 2013, 2014, 2015, 2016 CERN.
 #
 # Flask-Breadcrumbs is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -40,7 +40,6 @@ def default_breadcrumb_root(app, path):
 
 
 class Breadcrumbs(Menu, object):
-
     """Breadcrumb organizer for a :class:`~flask.Flask` application."""
 
     def __init__(self, app=None, init_menu=True):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-Breadcrumbs
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2016 CERN.
 #
 # Flask-Breadcrumbs is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -9,4 +9,4 @@
 
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=flask_breadcrumbs --cov-report=term-missing tests flask_breadcrumbs
+addopts = --pep8 --ignore=docs --cov=flask_breadcrumbs --cov-report=term-missing tests flask_breadcrumbs

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-Breadcrumbs
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2016 CERN.
 #
 # Flask-Breadcrumbs is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -51,7 +51,8 @@ tests_require = [
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.6.1',
+    'pytest>=2.8.0',
+    'pep257>=0.7.0',
     'coverage'
 ]
 
@@ -76,6 +77,7 @@ setup(
     ],
     extras_require={
         'docs': ['sphinx'],
+        'tests': tests_require,
     },
     tests_require=tests_require,
     cmdclass={'test': PyTest},


### PR DESCRIPTION
* Fixes Travis CI build tests by upgrading pytest, amending pep257 code
  style, and removing `--use-mirrors` directive.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>