### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,9 +2,9 @@ Authors
 =======
 
 Flask-Breadcrumbs is developed for use in
-`Invenio <http://invenio-software.org>`_ digital library software.
+`Invenio <http://inveniosoftware.org>`_ digital library software.
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 * Krzysztof Lis <krzysztof.lis@cern.ch>
 * Jiri Kuncar <jiri.kuncar@cern.ch>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -36,8 +36,8 @@ Homepage
 Good luck and thanks for choosing Flask-Breadcrumbs.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: http://github.com/inveniosoftware
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     url='http://github.com/inveniosoftware/flask-breadcrumbs/',
     license='BSD',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description='Flask-Breadcrumbs is a Flask extension that adds support '
         'for generating site breadcrumb navigation.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>